### PR TITLE
Adds "scala.collection.Iterable" to allowed collection types.

### DIFF
--- a/src/main/kotlin/com/github/bjansen/intellij/pebble/psi/elements.kt
+++ b/src/main/kotlin/com/github/bjansen/intellij/pebble/psi/elements.kt
@@ -154,7 +154,7 @@ class PebbleInVariable(node: ASTNode) : PebblePsiElement(node), PsiNamedElement 
             var iteratedType: PsiType? = null
 
             InheritanceUtil.processSuperTypes(type, true) {
-                if (it.canonicalText.startsWith("java.lang.Iterable")
+                if ((it.canonicalText.startsWith("java.lang.Iterable") || it.canonicalText.startsWith("scala.collection.Iterable"))
                         && it is PsiClassType && it.parameters.isNotEmpty()) {
                     iteratedType = it.parameters[0]
                 }


### PR DESCRIPTION
This change makes this plugin work great in combination with https://github.com/sfxcode/pebble-scala/.

I did not write unit-tests for that, as this would require pulling the scala stack into the plugin build which you might not want ;)