### PR TITLE
Parse empty keyword

### DIFF
--- a/parser/src/main/antlr/com/github/bjansen/pebble/parser/PebbleLexer.g4
+++ b/parser/src/main/antlr/com/github/bjansen/pebble/parser/PebbleLexer.g4
@@ -155,6 +155,10 @@ NULL
     : 'null'
     ;
 
+EMPTY
+    : 'empty'
+    ;
+
 NONE
     : 'none'
     ;

--- a/parser/src/main/antlr/com/github/bjansen/pebble/parser/PebbleParser.g4
+++ b/parser/src/main/antlr/com/github/bjansen/pebble/parser/PebbleParser.g4
@@ -134,7 +134,7 @@ term
     ;
 
 test
-    : NOT? (NULL | identifier)
+    : NOT? (NULL | EMPTY | identifier)
     ;
 
 unary_op

--- a/src/main/kotlin/com/github/bjansen/intellij/pebble/psi/PebbleParserDefinition.kt
+++ b/src/main/kotlin/com/github/bjansen/intellij/pebble/psi/PebbleParserDefinition.kt
@@ -167,7 +167,7 @@ class PebbleParserDefinition : ParserDefinition {
 
         // "Soft" keywords can also be valid identifiers. We only highlight them when their parent is not a RULE_identifier
         val SOFT_KEYWORDS: TokenSet = PSIElementTypeFactory.createTokenSet(PebbleLanguage,
-            PebbleLexer.AS, PebbleLexer.FROM, PebbleLexer.IN, PebbleLexer.IMPORT, PebbleLexer.WITH)
+            PebbleLexer.AS, PebbleLexer.FROM, PebbleLexer.IN, PebbleLexer.IMPORT, PebbleLexer.WITH, PebbleLexer.EMPTY)
 
         val FILE = IFileElementType(Language.findInstance(PebbleLanguage::class.java))
 


### PR DESCRIPTION
It parses 'empty' as a keyword so it can get recognized and highlighted by plugin.
It fixes the bug, which causes the warning: 

> Unknown variable 'empty'